### PR TITLE
Update speedy to 0.7, cbor, pickle, rmp, xdr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,17 @@ edition = "2018"
 
 "byteorder" = "1"
 "rmp" = "0.8"
-"rmp-serde" = "0.13"
+"rmp-serde" = "0.15"
 "bincode" = "1"
 "serde_json" = "1"
 "prost" = "0.4"
 "prost-derive" = "0.4"
 "bytes" = "0.4"
-"serde-pickle" = "0.4"
-"serde-xdr" = "0.5"
-"serde_cbor" = "0.9"
+"serde-pickle" = "0.6"
+"serde-xdr" = "0.6"
+"serde_cbor" = "0.11"
 
-"speedy" = "0.4"
+"speedy" = "0.7.1"
 "speedy-derive" = "0.3"
 
 [profile.release]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use {
         Serialize,
         Deserialize
     },
-    speedy_derive::{
+    speedy::{
         Writable,
         Readable
     }
@@ -262,7 +262,9 @@ macro_rules! speedy_benches {
             let value = default_value();
             b.iter( || {
                 let mut buffer = empty_vec();
-                value.write_to_stream( $endianness, &mut buffer ).unwrap();
+                value
+                    .write_to_stream_with_ctx($endianness, &mut buffer)
+                    .unwrap();
                 buffer
             });
         }
@@ -273,10 +275,13 @@ macro_rules! speedy_benches {
 
             let value = default_value();
             let mut buffer = empty_vec();
-            value.write_to_stream( $endianness, &mut buffer ).unwrap();
+            value
+                .write_to_stream_with_ctx($endianness, &mut buffer)
+                .unwrap();
 
-            b.iter( || {
-                let deserialized: Foo = Readable::read_from_buffer( $endianness, &buffer ).unwrap();
+            b.iter(|| {
+                let deserialized: Foo =
+                    Readable::read_from_buffer_with_ctx($endianness, &buffer).unwrap();
                 deserialized
             });
         }


### PR DESCRIPTION
I updated speedy and the other crates that didn't require code changes.

On my machine, here's the before:
```
test deserialize_manual                    ... bench:          37 ns/iter (+/- 2)
test deserialize_manual_foreign_endianness ... bench:          38 ns/iter (+/- 2)
test deserialize_speedy                    ... bench:          41 ns/iter (+/- 2)
test deserialize_speedy_foreign_endianness ... bench:          41 ns/iter (+/- 2)
test deserialize_serde_bincode             ... bench:          55 ns/iter (+/- 4)

test serialize_manual                      ... bench:          46 ns/iter (+/- 2)
test serialize_manual_foreign_endianness   ... bench:          47 ns/iter (+/- 3)
test serialize_speedy                      ... bench:          49 ns/iter (+/- 2)
test serialize_speedy_foreign_endianness   ... bench:          50 ns/iter (+/- 3)
test serialize_prost                       ... bench:          76 ns/iter (+/- 4)
test serialize_rmp                         ... bench:          88 ns/iter (+/- 6)
test serialize_serde_bincode               ... bench:          91 ns/iter (+/- 6)
test serialize_serde_xdr                   ... bench:         115 ns/iter (+/- 5)
test serialize_serde_cbor                  ... bench:         135 ns/iter (+/- 8)
test serialize_serde_rmp                   ... bench:         241 ns/iter (+/- 14)
test serialize_serde_pickle                ... bench:         297 ns/iter (+/- 14)
test serialize_serde_json                  ... bench:         439 ns/iter (+/- 38)
```

and after:
```
test deserialize_manual                    ... bench:          37 ns/iter (+/- 2)
test deserialize_manual_foreign_endianness ... bench:          37 ns/iter (+/- 2)
test deserialize_speedy                    ... bench:          47 ns/iter (+/- 2)
test deserialize_speedy_foreign_endianness ... bench:          47 ns/iter (+/- 3)
test deserialize_serde_bincode             ... bench:          54 ns/iter (+/- 4)

test serialize_rmp                         ... bench:          45 ns/iter (+/- 2)
test serialize_manual_foreign_endianness   ... bench:          47 ns/iter (+/- 3)
test serialize_manual                      ... bench:          49 ns/iter (+/- 3)
test serialize_speedy_foreign_endianness   ... bench:          53 ns/iter (+/- 4)
test serialize_speedy                      ... bench:          54 ns/iter (+/- 2)
test serialize_prost                       ... bench:          81 ns/iter (+/- 5)
test serialize_serde_bincode               ... bench:          94 ns/iter (+/- 5)
test serialize_serde_xdr                   ... bench:         119 ns/iter (+/- 7)
test serialize_serde_rmp                   ... bench:         154 ns/iter (+/- 7)
test serialize_serde_cbor                  ... bench:         183 ns/iter (+/- 11)
test serialize_serde_pickle                ... bench:         327 ns/iter (+/- 16)
test serialize_serde_json                  ... bench:         457 ns/iter (+/- 22)
```