### PR TITLE
update to latest version of all packages & add some cbor focused benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2018"
 "serde-pickle" = "0.6"
 "serde-xdr" = "0.6"
 "serde_cbor" = "0.11"
+"ciborium" = "0.1"
 
 "speedy" = "0.7"
 "speedy-derive" = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ edition = "2018"
 
 "byteorder" = "1"
 "rmp" = "0.8"
-"rmp-serde" = "0.13"
+"rmp-serde" = "0.15"
 "bincode" = "1"
 "serde_json" = "1"
-"prost" = "0.4"
-"prost-derive" = "0.4"
-"bytes" = "0.4"
-"serde-pickle" = "0.4"
-"serde-xdr" = "0.5"
-"serde_cbor" = "0.9"
+"prost" = "0.6"
+"prost-derive" = "0.6"
+"bytes" = "1"
+"serde-pickle" = "0.6"
+"serde-xdr" = "0.6"
+"serde_cbor" = "0.11"
 
-"speedy" = "0.4"
-"speedy-derive" = "0.3"
+"speedy" = "0.7"
+"speedy-derive" = "0.7"
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,30 @@ fn deserialize_serde_bincode( b: &mut Bencher ) {
 }
 
 #[bench]
+fn deserialize_serde_cbor( b: &mut Bencher ) {
+    let value = default_value();
+    let mut buffer = Vec::new();
+    serde_cbor::to_writer(&mut buffer, &value).unwrap();
+
+    b.iter( || {
+        let deserialized: Foo = serde_cbor::de::from_slice(&buffer).unwrap();
+        deserialized
+    });
+}
+
+#[bench]
+fn deserialize_serde_ciborium( b: &mut Bencher ) {
+    let value = default_value();
+    let mut buffer = Vec::new();
+    ciborium::ser::into_writer(&value, &mut buffer).unwrap();
+
+    b.iter( || {
+        let deserialized: Foo = ciborium::de::from_reader(std::io::Cursor::new(&buffer)).unwrap();
+        deserialized
+    });
+}
+
+#[bench]
 fn serialize_serde_json( b: &mut Bencher ) {
     let value = default_value();
 
@@ -360,6 +384,17 @@ fn serialize_serde_cbor( b: &mut Bencher ) {
     b.iter( || {
         let mut buffer = empty_vec();
         serde_cbor::ser::to_writer( &mut buffer, &value ).unwrap();
+        buffer
+    });
+}
+
+#[bench]
+fn serialize_serde_ciborium( b: &mut Bencher ) {
+    let value = default_value();
+
+    b.iter( || {
+        let mut buffer = empty_vec();
+        ciborium::ser::into_writer(&value, &mut buffer).unwrap();
         buffer
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ macro_rules! speedy_benches {
             let value = default_value();
             b.iter( || {
                 let mut buffer = empty_vec();
-                value.write_to_stream( $endianness, &mut buffer ).unwrap();
+                value.write_to_stream_with_ctx( $endianness, &mut buffer ).unwrap();
                 buffer
             });
         }
@@ -273,10 +273,10 @@ macro_rules! speedy_benches {
 
             let value = default_value();
             let mut buffer = empty_vec();
-            value.write_to_stream( $endianness, &mut buffer ).unwrap();
+            value.write_to_stream_with_ctx( $endianness, &mut buffer ).unwrap();
 
             b.iter( || {
-                let deserialized: Foo = Readable::read_from_buffer( $endianness, &buffer ).unwrap();
+                let deserialized: Foo = Readable::read_from_buffer_with_ctx( $endianness, &buffer ).unwrap();
                 deserialized
             });
         }


### PR DESCRIPTION
This a superset of #1 (but also bumps prost, bytes, speedy-derive).

The second commit extends the benchmark to include deserialization for serde_cbor and ciborium, and serialization for ciborium.